### PR TITLE
add tolerations for tforc-post job pods

### DIFF
--- a/internal/tfhandler/tfhandler.go
+++ b/internal/tfhandler/tfhandler.go
@@ -42,10 +42,11 @@ type informer struct {
 	cache                 *gocache.Cache
 	queue                 *deque.Deque[tfv1beta1.Terraform]
 	postJobContainerImage string
+	postJobTolerations    []byte
 	clusterName           string
 }
 
-func NewInformer(config *rest.Config, clientSetup tfoapiclient.ClientSetup, host, user, password string, insecureSkipVerify bool, postJobContainerImage string) informer {
+func NewInformer(config *rest.Config, clientSetup tfoapiclient.ClientSetup, host, user, password string, insecureSkipVerify bool, postJobContainerImage string, postJobTolerations []byte) informer {
 	log.Println("Setting up")
 	dynamicClient := dynamic.NewForConfigOrDie(config)
 	clientset, err := tfoapiclient.NewClientset(host, user, password, insecureSkipVerify)
@@ -90,6 +91,7 @@ func NewInformer(config *rest.Config, clientSetup tfoapiclient.ClientSetup, host
 		cache:                 gocache.New(10*time.Minute, 10*time.Minute),
 		queue:                 &deque.Deque[tfv1beta1.Terraform]{},
 		postJobContainerImage: postJobContainerImage,
+		postJobTolerations:    postJobTolerations,
 	}
 
 	handler := cache.ResourceEventHandlerFuncs{

--- a/main.go
+++ b/main.go
@@ -51,13 +51,14 @@ func main() {
 	clusterManifest := readFile(os.Getenv("TFO_API_CLUSTER_MANIFEST"))
 	vClusterManifest := readFile(os.Getenv("TFO_API_VCLUSTER_MANIFEST"))
 	postJobContainerImage := os.Getenv("POST_JOB_CONTAINER_IMAGE")
+	postJobTolerations := readFile(os.Getenv("POST_JOB_TOLERATIONS"))
 	url := fmt.Sprintf("%s://%s:%s", proto, host, port)
 	clientSetup := tfoapiclient.ClientSetup{
 		ClusterName:      clientName,
 		ClusterManifest:  clusterManifest,
 		VClusterManifest: vClusterManifest,
 	}
-	tfinformer := tfhandler.NewInformer(kubernetesConfig(kubeconfig), clientSetup, url, user, password, insecureSkipVerify, postJobContainerImage)
+	tfinformer := tfhandler.NewInformer(kubernetesConfig(kubeconfig), clientSetup, url, user, password, insecureSkipVerify, postJobContainerImage, postJobTolerations)
 	tfinformer.Run()
 	os.Exit(1) // should this be 0 instead?
 }


### PR DESCRIPTION
tforc-post pods are unable to run on clusters that require tolerations. This change along with a terraform-operator-remote-controller chart update will allow tolerations to be passed in 